### PR TITLE
main_ui: drop unused variable

### DIFF
--- a/src/main_ui.cpp
+++ b/src/main_ui.cpp
@@ -295,7 +295,6 @@ Component FromTable(Component prefix,
 
       std::map<std::string, int> columns_index;
       for (auto& row : json_.items()) {
-        std::vector<Component> components_row;
         children_.push_back({});
         auto& children_row = children_.back();
         for (auto& cell : row.value().items()) {


### PR DESCRIPTION
components_row is not used in FromTable(), so drop it.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>